### PR TITLE
Removed 33px offset

### DIFF
--- a/timber-debug-bar.css
+++ b/timber-debug-bar.css
@@ -22,10 +22,6 @@
     font-family: Consolas, mono, serif;
 }
 
-#wpadminbar .ab-top-secondary {
-    top: -33px;
-}
-
 #debug-bar-actions span {
     padding: 3px;
 }


### PR DESCRIPTION
Not sure, what the top offset was for, but it caused problems on wordpress 5.5.